### PR TITLE
Speed up on sending responses for ESP8266

### DIFF
--- a/aWOT.cpp
+++ b/aWOT.cpp
@@ -608,6 +608,10 @@ size_t Response::write(uint8_t ch) {
   return m_clientObject->write(ch);
 }
 
+size_t Response::write(uint8_t* ch, size_t size) {
+  return m_clientObject->write(ch, size);
+}
+
 /* Sets a header name and value pair to the response. */
 void Response::set(const char *name, const char *value) {
   if (m_headersCount < SIZE(m_headers)) {

--- a/aWOT.h
+++ b/aWOT.h
@@ -185,6 +185,7 @@ public:
   void printP(const char *str) {printP((unsigned char*) str);}
   void writeP(const unsigned char *data, size_t length);
   size_t write(uint8_t ch);
+  size_t write(uint8_t *ch, size_t size);
 
   void set(const char* name, const char* value);
 


### PR DESCRIPTION
Sending messages in 32 bytes chunks (as printP and writeP do) makes the communication too slow on ESP8266, so I added a write(char*, size_t) function to be able to send the full message in only one piece if you know what you are doing.