### PR TITLE
Express initialization to NULL of list tail pointers 

### DIFF
--- a/aWOT.cpp
+++ b/aWOT.cpp
@@ -23,6 +23,8 @@
 
 #include <aWOT.h>
 
+Request::HeaderNode* WebApp::m_headerTail = NULL;
+
 /* Request constructor. */
 Request::Request() :
   m_queryComplete(false),
@@ -745,6 +747,9 @@ void Response::m_printHeaders() {
     m_printCRLF();
   }
 }
+
+Router::CommandNode* Router::m_tailCommand = NULL;
+Router* Router::m_next = NULL;
 
 /* Router class constructor with an optional URL prefix parameter */
 Router::Router(const char * urlPrefix) :

--- a/aWOT.h
+++ b/aWOT.h
@@ -253,8 +253,8 @@ private:
     CommandNode* next;
   };
 
-  CommandNode* m_tailCommand;
-  Router* m_next;
+  static CommandNode* m_tailCommand;
+  static Router* m_next;
 
   bool m_routeMatch(const char *str, const char *pattern);
   const char * m_urlPrefix;
@@ -299,7 +299,7 @@ private:
   Router::Middleware* m_failureCommand;
   Router::Middleware* m_notFoundCommand;
 
-  Request::HeaderNode* m_headerTail;
+  static Request::HeaderNode* m_headerTail;
 
 };
 


### PR DESCRIPTION
This is required in some platforms. At least on my compilation scenario for ESP8266 is tested to work, and does not hurt.