### PR TITLE
Define changed for compatibility with ESP32 chips

### DIFF
--- a/aWOT.h
+++ b/aWOT.h
@@ -72,7 +72,11 @@
 #define SERVER_SERVER_ERROR_MESSAGE "<h1>500 Internal Server Error</h1>"
 #endif
 
+#ifdef ESP32
+extern "C" uint32_t millis(void);
+#else 
 extern "C" unsigned long millis(void);
+#endif
 
 #define P(name) static const unsigned char name[] PROGMEM
 


### PR DESCRIPTION
Iwas using aWOT in ESP32 this weekend and I need to change this to make it work. Nothing else. After this change everythig works like charm.