### PR TITLE
Update `include` for local search path

### DIFF
--- a/aWOT.cpp
+++ b/aWOT.cpp
@@ -21,7 +21,7 @@
  THE SOFTWARE.
  */
 
-#include <aWOT.h>
+#include "aWOT.h"
 
 /* Request constructor. */
 Request::Request() :


### PR DESCRIPTION
Just a lite change to make the lib usage more flexiable:

By using `#include ".."` instead of `#include <..>` the local search path is respected as well, which allows the lib to be used in a local project folder too.