### PR TITLE
Fix last header handling

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=aWOT
-version=1.1.0
+version=1.1.1
 author=Lasse Lukkari <lasse.lukkari@gmail.com>
 maintainer=Lasse Lukkari <lasse.lukkari@gmail.com>
 sentence=Arduino web server library.

--- a/src/aWOT.cpp
+++ b/src/aWOT.cpp
@@ -391,6 +391,11 @@ bool Request::m_processHeaders(HeaderNode *headerTail) {
     }
 
     if (match) {
+      if(m_expect(CRLF)) {
+        m_readingContent = true;
+        return true;
+      }
+
       continue;
     }
 
@@ -413,7 +418,7 @@ bool Request::m_headerValue(char *buffer, int bufferLength) {
     ;
   push(ch);
 
-  while ((ch = read()) != -1 && ch != '\r') {
+  while (!m_expect(CRLF) && (ch = read()) != -1) {
     if (--bufferLength > 0) {
       *buffer++ = ch;
     }


### PR DESCRIPTION
This bug caused the request to timeout if the last header of the request was read.