### PR TITLE
Fix reset

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=aWOT
-version=1.1.2
+version=1.1.3
 author=Lasse Lukkari <lasse.lukkari@gmail.com>
 maintainer=Lasse Lukkari <lasse.lukkari@gmail.com>
 sentence=Arduino web server library.

--- a/src/aWOT.cpp
+++ b/src/aWOT.cpp
@@ -1168,7 +1168,7 @@ void Response::m_flushBuf() {
 }
 
 void Response::m_reset() {
-  flush();
+  m_flushBuf();
 
   if (m_headersSent && !m_contentLenghtSet) {
     m_stream->print(0, HEX);


### PR DESCRIPTION
On some platform the the flush function also wipes out the incoming rx buffer. Calling flush can be done outside the library if really needed.