### PR TITLE
Add support to define a custom 'not found' error

### DIFF
--- a/examples/Ethernet/Ethernet.ino
+++ b/examples/Ethernet/Ethernet.ino
@@ -26,6 +26,19 @@ void indexCmd(Request &req, Response &res) {
 
 }
 
+void overwritedNotFound(Request &req, Response &res){
+
+    res.status(404);
+    res.set("Content-Type", "application/json");
+    res.print(F("{\"error\":\"route not found\"}"));
+
+    Serial.print("Route: ");
+    Serial.print(req.path());
+    Serial.print(" error 404 'Not Found' from client: ");
+    Serial.println(((EthernetClient*)req.stream())->remoteIP());
+
+}
+
 void setup() {
 
   Serial.begin(115200);

--- a/src/aWOT.cpp
+++ b/src/aWOT.cpp
@@ -22,6 +22,8 @@
 
 #include "aWOT.h"
 
+__attribute__((weak)) void overwritedNotFound(Request &req, Response &res);
+
 Response::Response()
     : m_stream(NULL),
       m_headers(),
@@ -1550,7 +1552,12 @@ void Application::m_process() {
   }
 
   if (!routeMatch && !m_response.ended() && !m_response.headersSent()) {
-    return m_response.sendStatus(404);
+    // Call custom user function for route not found if defined
+    if (overwritedNotFound){
+        overwritedNotFound(m_request, m_response); 
+    }else{
+        return m_response.sendStatus(404);
+    }
   }
 
   if (!m_response.ended() && !m_response.headersSent()) {


### PR DESCRIPTION
Hi.

Congrats for your nice project.

I have needed to define a custom response in case of 404 error, but have not seen any facility to do so.
This is the way that I am doing it. If there is any other better way, please let me know.

Regards.
Jorge.