### PR TITLE
Added note to Hello world app

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ void loop() {
 
   if (client.connected()) {
     app.process(&client);
+    // If you are using the EthernetClient remember to call client.stop() here.
   }
 }
 ```


### PR DESCRIPTION
client.stop() must be called for Ethernet Server. 
WIll be good to say that here.
It can only be found in the Ethernet Example