### PR TITLE
Allow writing data from AVR far pointers

### DIFF
--- a/src/aWOT.cpp
+++ b/src/aWOT.cpp
@@ -229,6 +229,18 @@ size_t Response::write(uint8_t *buffer, size_t bufferLength) {
   return bufferLength;
 }
 
+size_t Response::write(const uint_farptr_t data, size_t length) {
+    uint_farptr_t ptr = data;
+    if (m_shouldPrintHeaders()) {
+        m_printHeaders();
+    }
+
+    while (length--) {
+        write(pgm_read_byte_far(ptr++));
+    }
+    return length;
+}
+
 void Response::writeP(const unsigned char *data, size_t length) {
   if (m_shouldPrintHeaders()) {
     m_printHeaders();

--- a/src/aWOT.h
+++ b/src/aWOT.h
@@ -123,6 +123,10 @@ class Response : public Print {
   int statusSent();
   size_t write(uint8_t data);
   size_t write(uint8_t* buffer, size_t bufferLength);
+  /**
+   * Write from program memory via a 32 bit AVR "far pointer".
+   */
+  size_t write(const uint_farptr_t data, size_t length);
   void writeP(const unsigned char* data, size_t length);
 
  private:


### PR DESCRIPTION
Helpful when working with AVRs with more than 64k of Flash.

Those units still only use 16 bit pointers, but store their data in "pages" that the normal `write` or `writeP` functions can not handle.