### PR TITLE
Add required header for GCC 13 compatibility

### DIFF
--- a/test/unittest/Compare.h
+++ b/test/unittest/Compare.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <pgmspace.h>
 #include <WString.h>
 


### PR DESCRIPTION
Recently Github Actions has updated the Ubuntu workfollow workers from version 22.04 to 24.04, as announced here: https://github.com/actions/runner-images/issues/10636

This update is accompanied by the update of the GCC version from 11.4.0 to 13.3.0, which introduces changes in the header file dependency as indicated here: https://gcc.gnu.org/gcc-13/porting_to.html

This small fix is required for this reason, so that tests can be built without errors.

Best regards.
